### PR TITLE
feat: Implement "Selection JSON Specification"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Full documentation available at [keyple.org](https://keyple.org)
 
 ## Build
 The code is built with **Gradle** and targets **Android**, **iOS**, and **JVM** platforms.
+To build and publish the artifacts for all supported targets locally, use:
+```
+./gradlew publishAllPublicationsToMavenLocalRepository
+```
+Note: you need to use a mac to build or use iOS artifacts. Learn more about [Kotlin Multiplatform](https://www.jetbrains.com/help/kotlin-multiplatform-dev/get-started.html)…
+
 
 ## API Documentation
 API documentation & class diagrams are available

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 title = Keyple Kotlin Multiplatform Distributed Client Library
 description = Keyple Distributed Client KMP Library - A Kotlin Multiplatform implementation enabling distributed remote client communications across Android, iOS and desktop platforms
 group = org.eclipse.keyple
-version = 0.1.4
+version = 0.1.5
 
 kotlin.code.style=official
 

--- a/src/commonMain/kotlin/org/eclipse/keyple/keypleless/distributed/client/protocol/CardSelectionScenario.kt
+++ b/src/commonMain/kotlin/org/eclipse/keyple/keypleless/distributed/client/protocol/CardSelectionScenario.kt
@@ -1,0 +1,30 @@
+/* **************************************************************************************
+ * Copyright (c) 2025 Calypso Networks Association https://calypsonet.org/
+ *
+ * See the NOTICE file(s) distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License 2.0 which is available at http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ************************************************************************************** */
+package org.eclipse.keyple.keypleless.distributed.client.protocol
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class DefaultCardSelection(val cardSelectionRequest: CardSelectionRequest)
+
+@Serializable
+internal data class CardSelectionScenario(
+    val multiSelectionProcessing: MultiSelectionProcessing,
+    val channelControl: ChannelControl,
+    val cardSelectors: Array<CardSelector>,
+    val defaultCardSelections: Array<DefaultCardSelection>
+)
+
+@Serializable
+internal data class ProcessedCardSelectionScenario(
+    val processedCardSelectionScenarioJsonString: String
+)

--- a/src/commonMain/kotlin/org/eclipse/keyple/keypleless/distributed/client/protocol/KeypleProtocol.kt
+++ b/src/commonMain/kotlin/org/eclipse/keyple/keypleless/distributed/client/protocol/KeypleProtocol.kt
@@ -12,6 +12,7 @@
 package org.eclipse.keyple.keypleless.distributed.client.protocol
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 
 const val API_LEVEL = 3
 const val CORE_API_LEVEL = 2
@@ -47,7 +48,9 @@ internal data class ExecuteRemoteServiceBody<T>(
     val coreApiLevel: Int,
     val serviceId: String,
     val isReaderContactless: Boolean = true,
-    val inputData: T?
+    val inputData: T?,
+    val initialCardContent: JsonElement? = null,
+    val initialCardContentClassName: String? = null
 )
 
 @Serializable

--- a/src/commonMain/kotlin/org/eclipse/keyple/keypleless/distributed/client/protocol/KeypleProtocol.kt
+++ b/src/commonMain/kotlin/org/eclipse/keyple/keypleless/distributed/client/protocol/KeypleProtocol.kt
@@ -23,8 +23,6 @@ const val END_REMOTE_SERVICE = "END_REMOTE_SERVICE"
 
 const val RESP = "RESP"
 
-const val IS_CONTACTLESS = "IS_CONTACTLESS"
-
 const val IS_CARD_PRESENT = "IS_CARD_PRESENT"
 
 const val TRANSMIT_CARD_SELECTION_REQUESTS = "TRANSMIT_CARD_SELECTION_REQUESTS"
@@ -70,14 +68,6 @@ enum class ErrorCode {
 internal data class CmdBody(
     val coreApiLevel: Int = CORE_API_LEVEL,
     val service: String,
-)
-
-@Serializable
-internal data class IsContactlessRespBody(
-    val coreApiLevel: Int = CORE_API_LEVEL,
-    val service: String = "IS_CONTACTLESS",
-    val result: Boolean?,
-    val error: Error? = null
 )
 
 @Serializable

--- a/src/commonMain/kotlin/org/eclipse/keyple/keypleless/distributed/client/protocol/KeypleTerminal.kt
+++ b/src/commonMain/kotlin/org/eclipse/keyple/keypleless/distributed/client/protocol/KeypleTerminal.kt
@@ -48,7 +48,7 @@ class KeypleTerminal(
     return reader.waitForCardPresent()
   }
 
-  suspend fun waitForCard(onCard: () -> Unit) {
+  fun waitForCard(onCard: () -> Unit) {
     reader.startCardDetection { onCard() }
   }
 

--- a/src/commonMain/kotlin/org/eclipse/keyple/keypleless/distributed/client/protocol/KeypleTerminal.kt
+++ b/src/commonMain/kotlin/org/eclipse/keyple/keypleless/distributed/client/protocol/KeypleTerminal.kt
@@ -121,13 +121,11 @@ class KeypleTerminal(
 
         val deviceAnswer =
             when (service) {
-              IS_CONTACTLESS -> messageProcessor.isContactless()
               IS_CARD_PRESENT -> messageProcessor.isCardPresent()
               TRANSMIT_CARD_SELECTION_REQUESTS -> transmitCardSelectionRequests(serverResponse)
               TRANSMIT_CARD_REQUEST -> transmitCardRequest(serverResponse)
               else -> {
-                // TODO check what should we do here? throw an Exception?
-                ""
+                  return KeypleResult.Failure(KeypleError(statusCode = -1, message = "Unknown request: $service"))
               }
             }
 

--- a/src/commonMain/kotlin/org/eclipse/keyple/keypleless/distributed/client/protocol/MessageProcessor.kt
+++ b/src/commonMain/kotlin/org/eclipse/keyple/keypleless/distributed/client/protocol/MessageProcessor.kt
@@ -28,7 +28,7 @@ internal class MessageProcessor(private val json: Json) {
   }
 
   fun isCardPresent(): String {
-    // TODO: maybe we need to be smarter here?...
+    // TODO: maybe we need to be smarter here for desktop pcsc readers?...
     val resp = IsCardPresentRespBody(result = true)
     return json.encodeToString(resp)
   }

--- a/src/commonMain/kotlin/org/eclipse/keyple/keypleless/distributed/client/protocol/MessageProcessor.kt
+++ b/src/commonMain/kotlin/org/eclipse/keyple/keypleless/distributed/client/protocol/MessageProcessor.kt
@@ -22,11 +22,6 @@ private const val SW2_MASK: Int = 0x00FF
 
 internal class MessageProcessor(private val json: Json) {
 
-  fun isContactless(): String {
-    val resp = IsContactlessRespBody(result = true)
-    return json.encodeToString(resp)
-  }
-
   fun isCardPresent(): String {
     // TODO: maybe we need to be smarter here for desktop pcsc readers?...
     val resp = IsCardPresentRespBody(result = true)

--- a/src/commonMain/kotlin/org/eclipse/keyple/keypleless/distributed/client/spi/LocalReader.kt
+++ b/src/commonMain/kotlin/org/eclipse/keyple/keypleless/distributed/client/spi/LocalReader.kt
@@ -33,7 +33,7 @@ interface LocalReader {
   suspend fun waitForCardPresent(): Boolean
 
   /** @throws ReaderIOException on IO error communicating with the reader (USB unplugged, etc.) */
-  suspend fun startCardDetection(onCardFound: () -> Unit)
+  fun startCardDetection(onCardFound: () -> Unit)
 
   /**
    * @throws ReaderIOException on IO error communicating with the reader (USB unplugged, etc.)


### PR DESCRIPTION
Implement the optional Selection JSON Specification. This feature allows, using a "Selection Scenario" (generally retrieved once from the server), to perform the card detection locally on the Terminal endpoint and transmit the result of this Selection Scenario to the Keyple server on the first http contact.
This feature saves (at least) one HTTP round trip, which is significant for a "typical" keyple session that uses 3 or 4 HTTP round trips. Hence it's highly recommended to use it!